### PR TITLE
Bug fix for spacing around image

### DIFF
--- a/cropper/src/com/edmodo/cropper/CropImageView.java
+++ b/cropper/src/com/edmodo/cropper/CropImageView.java
@@ -274,8 +274,8 @@ public class CropImageView extends ImageView {
         final float transY = matrixValues[Matrix.MTRANS_Y];
 
         // Ensure that the left and top edges are not outside of the ImageView bounds.
-        final float bitmapLeft = (transX < 0) ? Math.abs(transX) : 0;
-        final float bitmapTop = (transY < 0) ? Math.abs(transY) : 0;
+        final float bitmapLeft = -transX;
+        final float bitmapTop = -transY;
 
         // Get the original bitmap object.
         final Bitmap originalBitmap = ((BitmapDrawable) drawable).getBitmap();


### PR DESCRIPTION
Bug fix: When the image is scaleType="fitCenter", there can be extra space left or above the image depending on the layout. The bug is that the extra space is either making the wrong area get cropped or an exception is thrown by createBitmap (width/height cannot be 0 or negative).

https://github.com/edmodo/cropper/issues/134